### PR TITLE
Let anonymous users access swagger documentation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/coh/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/config/SecurityConfiguration.java
@@ -31,10 +31,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .addFilter(filter)
             .csrf().disable()
             .authorizeRequests()
-            .antMatchers("/actuator**").permitAll()
-            .antMatchers("/error", "/health").permitAll()
-            .antMatchers("/SSCS/*").permitAll()
-            .antMatchers("/swagger**").permitAll()
+            .antMatchers("/error", "/health").anonymous()
+            .antMatchers("/SSCS/*").anonymous()
+            .antMatchers("/swagger-ui.html", "/swagger-resources/**", "/webjars/**", "/v2/api-docs").anonymous()
             .anyRequest().authenticated();
     }
 }


### PR DESCRIPTION
Latest changes effectively blocked swagger. This change is to re-enable it for everyone.