### PR TITLE
Add test for question deadline behaviour

### DIFF
--- a/src/aat/resources/cucumber/deadline-extension.feature
+++ b/src/aat/resources/cucumber/deadline-extension.feature
@@ -39,8 +39,8 @@ Feature: Deadline Extension
     Then the response code is 200
     And question states are question_deadline_extension_granted
     And a standard question
-    And the post request is sent to create the question
-    When the put request is sent to issue the question round ' "2" '
+    Given the question round is ' "2" '
+    When the post request is sent to create the question
     Then the response code is 200
 
   Scenario: Cannot extend deadline without questions

--- a/src/aat/resources/cucumber/deadline-extension.feature
+++ b/src/aat/resources/cucumber/deadline-extension.feature
@@ -14,6 +14,35 @@ Feature: Deadline Extension
     And question history has at least 2 events
     And an event has been queued for this online hearing of event type question_deadline_extension_granted
 
+  Scenario: Extended deadline questions can be answered
+    Given a standard online hearing is created
+    And a standard question
+    And the post request is sent to create the question
+    And a standard question
+    And the post request is sent to create the question
+    When the put request is sent to issue the question round ' "1" '
+    And deadline extension is requested
+    Then the response code is 200
+    And question states are question_deadline_extension_granted
+    And a standard answer
+    When a POST request is sent for an answer
+    Then the response code is 201
+
+  Scenario: Question round may be issued after question deadline is extended
+    Given a standard online hearing is created
+    And a standard question
+    And the post request is sent to create the question
+    And a standard question
+    And the post request is sent to create the question
+    When the put request is sent to issue the question round ' "1" '
+    And deadline extension is requested
+    Then the response code is 200
+    And question states are question_deadline_extension_granted
+    And a standard question
+    And the post request is sent to create the question
+    When the put request is sent to issue the question round ' "2" '
+    Then the response code is 200
+
   Scenario: Cannot extend deadline without questions
     Given a standard online hearing is created
     And deadline extension is requested

--- a/src/aat/resources/cucumber/deadline-extension.feature
+++ b/src/aat/resources/cucumber/deadline-extension.feature
@@ -41,7 +41,7 @@ Feature: Deadline Extension
     And a standard question
     Given the question round is ' "2" '
     When the post request is sent to create the question
-    Then the response code is 200
+    Then the response code is 201
 
   Scenario: Cannot extend deadline without questions
     Given a standard online hearing is created

--- a/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionRoundService.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionRoundService.java
@@ -39,7 +39,12 @@ public class QuestionRoundService {
     }
 
     public boolean alreadyIssued(QuestionRoundState questionRoundState) {
-        return questionRoundState.getState().equals(ISSUE_PENDING) || questionRoundState.getState().equals(ISSUED) || questionRoundState.getState().equals(QUESTIONS_ANSWERED);
+
+        return questionRoundState.getState().equals(ISSUE_PENDING)
+                || questionRoundState.getState().equals(ISSUED)
+                || questionRoundState.getState().equals(QUESTIONS_ANSWERED)
+                || questionRoundState.getState().equals(QuestionStates.QUESTION_DEADLINE_EXTENSION_GRANTED.getStateName())
+                || questionRoundState.getState().equals(QuestionStates.QUESTION_DEADLINE_EXTENSION_DENIED.getStateName());
     }
 
     public boolean isFirstRound(int currentRoundNumber) {
@@ -54,7 +59,7 @@ public class QuestionRoundService {
         QuestionRoundState currentState = retrieveQuestionRoundState(getQuestionRoundByRoundId(onlineHearing, currentRoundNumber));
 
         if(!isFirstRound(currentRoundNumber) && isIncremented(question.getQuestionRound(), currentRoundNumber)
-                && !currentState.getState().equals(QuestionStates.ISSUED.getStateName()) && !currentState.getState().equals(QUESTIONS_ANSWERED)){
+                && !alreadyIssued(currentState)){
             throw new NotAValidUpdateException("Cannot increment question round unless previous question round is issued");
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionRoundService.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionRoundService.java
@@ -67,10 +67,10 @@ public class QuestionRoundService {
             throw new NotAValidUpdateException("Cannot increment question round unless previous question round is issued");
         }
 
-        if (alreadyIssuedOrPending(currentState) && isIncremented(targetQuestionRound, currentRoundNumber)) {
+        if ((alreadyIssuedOrPending(currentState) && isIncremented(targetQuestionRound, currentRoundNumber))
+            || (!alreadyIssuedOrPending(currentState) && targetQuestionRound == currentRoundNumber || isFirstRound(currentRoundNumber)) ) {
             // Current QR is issued and create new question round
-            return true;
-        } else if (!alreadyIssuedOrPending(currentState) && targetQuestionRound == currentRoundNumber || isFirstRound(currentRoundNumber)) {
+            // or
             // Current QR is not issued and question is current question round OR no QR exists yet
             return true;
         }

--- a/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionRoundService.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionRoundService.java
@@ -66,8 +66,7 @@ public class QuestionRoundService {
                 && !alreadyIssued(currentState)){
             throw new NotAValidUpdateException("Cannot increment question round unless previous question round is issued");
         }
-
-        if ((alreadyIssuedOrPending(currentState) && isIncremented(targetQuestionRound, currentRoundNumber))
+        else if ((alreadyIssuedOrPending(currentState) && isIncremented(targetQuestionRound, currentRoundNumber))
             || (!alreadyIssuedOrPending(currentState) && targetQuestionRound == currentRoundNumber || isFirstRound(currentRoundNumber)) ) {
             // Current QR is issued and create new question round
             // or

--- a/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionRoundService.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionRoundService.java
@@ -40,11 +40,15 @@ public class QuestionRoundService {
 
     public boolean alreadyIssued(QuestionRoundState questionRoundState) {
 
-        return questionRoundState.getState().equals(ISSUE_PENDING)
-                || questionRoundState.getState().equals(ISSUED)
+        return questionRoundState.getState().equals(ISSUED)
                 || questionRoundState.getState().equals(QUESTIONS_ANSWERED)
                 || questionRoundState.getState().equals(QuestionStates.QUESTION_DEADLINE_EXTENSION_GRANTED.getStateName())
                 || questionRoundState.getState().equals(QuestionStates.QUESTION_DEADLINE_EXTENSION_DENIED.getStateName());
+    }
+
+    public boolean alreadyIssuedOrPending(QuestionRoundState questionRoundState) {
+
+        return alreadyIssued(questionRoundState) || questionRoundState.getState().equals(ISSUE_PENDING);
     }
 
     public boolean isFirstRound(int currentRoundNumber) {
@@ -64,12 +68,12 @@ public class QuestionRoundService {
         }
 
         // Current QR is issued and create new question round
-        if(alreadyIssued(currentState) && isIncremented(targetQuestionRound, currentRoundNumber)) {
+        if(alreadyIssuedOrPending(currentState) && isIncremented(targetQuestionRound, currentRoundNumber)) {
             return true;
         }
 
         // Current QR is not issued and question is current question round OR no QR exists yet
-        if(!alreadyIssued(currentState) && targetQuestionRound == currentRoundNumber || isFirstRound(currentRoundNumber)) {
+        if(!alreadyIssuedOrPending(currentState) && targetQuestionRound == currentRoundNumber || isFirstRound(currentRoundNumber)) {
             return true;
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionRoundService.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionRoundService.java
@@ -67,13 +67,11 @@ public class QuestionRoundService {
             throw new NotAValidUpdateException("Cannot increment question round unless previous question round is issued");
         }
 
-        // Current QR is issued and create new question round
-        if(alreadyIssuedOrPending(currentState) && isIncremented(targetQuestionRound, currentRoundNumber)) {
+        if (alreadyIssuedOrPending(currentState) && isIncremented(targetQuestionRound, currentRoundNumber)) {
+            // Current QR is issued and create new question round
             return true;
-        }
-
-        // Current QR is not issued and question is current question round OR no QR exists yet
-        if(!alreadyIssuedOrPending(currentState) && targetQuestionRound == currentRoundNumber || isFirstRound(currentRoundNumber)) {
+        } else if (!alreadyIssuedOrPending(currentState) && targetQuestionRound == currentRoundNumber || isFirstRound(currentRoundNumber)) {
+            // Current QR is not issued and question is current question round OR no QR exists yet
             return true;
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/coh/service/QuestionRoundServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/coh/service/QuestionRoundServiceTest.java
@@ -451,7 +451,7 @@ public class QuestionRoundServiceTest {
 
     @Test
     public void testAlreadyIssuedReturnsTrueIfQuestionStateIsIssuePending() {
-        assertTrue(questionRoundService.alreadyIssued(new QuestionRoundState(issuedPendingState)));
+        assertTrue(questionRoundService.alreadyIssuedOrPending(new QuestionRoundState(issuedPendingState)));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/coh/service/QuestionRoundServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/coh/service/QuestionRoundServiceTest.java
@@ -37,6 +37,8 @@ public class QuestionRoundServiceTest {
     private QuestionState submittedState;
     private QuestionState issuedState;
     private QuestionState issuedPendingState;
+    private QuestionState extensionGranted;
+    private QuestionState extensionDenied;
     private QuestionState answeredState;
     private QuestionState deadlineElapsedState;
     private List<Question> questionRound1Questions;
@@ -74,6 +76,9 @@ public class QuestionRoundServiceTest {
         issuedPendingState = new QuestionState();
         issuedPendingState.setQuestionStateId(3);
         issuedPendingState.setState(issuedPendingStateName);
+
+        extensionGranted = new QuestionState(QuestionStates.QUESTION_DEADLINE_EXTENSION_GRANTED.getStateName());
+        extensionDenied = new QuestionState(QuestionStates.QUESTION_DEADLINE_EXTENSION_DENIED.getStateName());
 
         answeredState = new QuestionState(getQuestionsAnsweredStateName);
         deadlineElapsedState = new QuestionState(deadlineElapsedStateName);
@@ -452,6 +457,16 @@ public class QuestionRoundServiceTest {
     @Test
     public void testAlreadyIssuedReturnsTrueIfQuestionStateIsIssuePending() {
         assertTrue(questionRoundService.alreadyIssuedOrPending(new QuestionRoundState(issuedPendingState)));
+    }
+
+    @Test
+    public void testAlreadyIssuedReturnsTrueIfQuestionStateExtensionGranted() {
+        assertTrue(questionRoundService.alreadyIssued(new QuestionRoundState(extensionGranted)));
+    }
+
+    @Test
+    public void testAlreadyIssuedReturnsTrueIfQuestionStateIsExtensionRejected() {
+        assertTrue(questionRoundService.alreadyIssued(new QuestionRoundState(extensionDenied)));
     }
 
     @Test


### PR DESCRIPTION
First test ensures a question can be answered while in question_deadline_extension_granted state.
Second test checks if a QR can created if the previous QR is in state question_extension_granted.