### PR TITLE
Refactor IdAM authentication for functional tests

### DIFF
--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/AnswerSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/AnswerSteps.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.reform.coh.functional.bdd.requests.CohEntityTypes;
 import uk.gov.hmcts.reform.coh.functional.bdd.responses.AnswerResponseUtils;
 import uk.gov.hmcts.reform.coh.functional.bdd.responses.QuestionResponseUtils;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestContext;
+import uk.gov.hmcts.reform.coh.idam.IdamAuthentication;
 import uk.gov.hmcts.reform.coh.repository.OnlineHearingRepository;
 import uk.gov.hmcts.reform.coh.repository.QuestionRepository;
 import uk.gov.hmcts.reform.coh.service.AnswerService;
@@ -50,8 +51,8 @@ public class AnswerSteps extends BaseSteps {
     private QuestionRepository questionRepository;
 
     @Autowired
-    public AnswerSteps(TestContext testContext) {
-        super(testContext);
+    public AnswerSteps(TestContext testContext, IdamAuthentication idamAuthentication) {
+        super(testContext, idamAuthentication);
     }
 
     @Before

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/ApiSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/ApiSteps.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.coh.controller.onlinehearing.CreateOnlineHearingRespo
 import uk.gov.hmcts.reform.coh.controller.onlinehearing.OnlineHearingRequest;
 import uk.gov.hmcts.reform.coh.domain.*;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestContext;
+import uk.gov.hmcts.reform.coh.idam.IdamAuthentication;
 import uk.gov.hmcts.reform.coh.repository.*;
 import uk.gov.hmcts.reform.coh.schedule.notifiers.EventNotifierJob;
 import uk.gov.hmcts.reform.coh.service.*;
@@ -85,8 +86,8 @@ public class ApiSteps extends BaseSteps {
     private Map<SessionEventForwardingRegister, String> originalSettings = new HashMap<>();
 
     @Autowired
-    public ApiSteps(TestContext testContext) {
-        super(testContext);
+    public ApiSteps(TestContext testContext, IdamAuthentication idamAuthentication) {
+        super(testContext, idamAuthentication);
     }
 
     @Before

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/BaseSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/BaseSteps.java
@@ -1,24 +1,13 @@
 package uk.gov.hmcts.reform.coh.functional.bdd.steps;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.coh.functional.bdd.requests.CohEndpointFactory;
 import uk.gov.hmcts.reform.coh.functional.bdd.requests.CohEndpointHandler;
@@ -26,18 +15,12 @@ import uk.gov.hmcts.reform.coh.functional.bdd.requests.CohEntityTypes;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestContext;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestTrustManager;
 import uk.gov.hmcts.reform.coh.handlers.IdamHeaderInterceptor;
+import uk.gov.hmcts.reform.coh.idam.IdamAuthentication;
 import uk.gov.hmcts.reform.coh.repository.SessionEventForwardingRegisterRepository;
-import uk.gov.hmcts.reform.coh.utils.JsonUtils;
 
-import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
-import java.util.function.Consumer;
-
-import static org.junit.Assert.fail;
 
 public class BaseSteps {
 
@@ -57,24 +40,15 @@ public class BaseSteps {
     @Value("${aat.test-notification-endpoint}")
     protected String testNotificationUrl;
 
-    @Value("${base-urls.idam-url}")
-    protected String idamUrl;
-
-    @Value("${base-urls.idam-user-email}")
-    private String idamEmail;
-
-    @Value("${base-urls.idam-user-role}")
-    protected String idamUserRole;
-
     protected TestContext testContext;
-    
+    private final IdamAuthentication idamAuthentication;
+
     protected HttpHeaders header;
 
-    protected Integer idamUser;
-
     @Autowired
-    public BaseSteps(TestContext testContext) {
+    public BaseSteps(TestContext testContext, IdamAuthentication idamAuthentication) {
         this.testContext = testContext;
+        this.idamAuthentication = idamAuthentication;
     }
 
     public void setup() throws Exception {
@@ -91,109 +65,13 @@ public class BaseSteps {
             .ifPresent(token -> header.add(IdamHeaderInterceptor.IDAM_SERVICE_AUTHORIZATION, token));
     }
 
-    protected static void withValidHttpCodes(Consumer<RestTemplate> consumer, int... codes) {
-        withValidHttpCodes(new RestTemplate(), consumer, codes);
-    }
-
-    protected static void withValidHttpCodes(RestTemplate rt, Consumer<RestTemplate> consumer, int... codes) {
-        ResponseErrorHandler oldErrorHandler = rt.getErrorHandler();
-        rt.setErrorHandler(new ResponseErrorHandler() {
-            @Override
-            public boolean hasError(ClientHttpResponse response) throws IOException {
-                for (int code : codes) {
-                    if (response.getRawStatusCode() == code) {
-                        return false;
-                    }
-                }
-                return oldErrorHandler.hasError(response);
-            }
-
-            @Override
-            public void handleError(ClientHttpResponse response) throws IOException {
-                oldErrorHandler.handleError(response);
-            }
-        });
-        consumer.accept(rt);
-    }
-
-    private void prepareAuthenticationTokens() throws Exception {
-        findIdamUserIdByEmail();
-        registerIfNecessary();
+    private void prepareAuthenticationTokens() {
         getIdamToken();
         getS2sToken();
     }
 
-    private void findIdamUserIdByEmail() {
-        String usersUri = UriComponentsBuilder.fromUriString(idamUrl)
-            .path("/testing-support/accounts/" + idamEmail)
-            .toUriString();
-
-        withValidHttpCodes(
-            rt -> {
-                ResponseEntity<Map> entity = rt.getForEntity(usersUri, Map.class);
-                if (entity.getStatusCode() == HttpStatus.OK && entity.hasBody() && entity.getBody().containsKey("id")) {
-                    idamUser = (Integer) entity.getBody().get("id");
-                }
-            },
-            404
-        );
-    }
-
-    private void registerIfNecessary() throws JsonProcessingException {
-        if (idamUser != null) {
-            return;
-        }
-        String idamPassword = UUID.randomUUID().toString();
-        ImmutableMap<String, Object> body = ImmutableMap.of(
-            "email", idamEmail,
-            "password", idamPassword,
-            "forename", "test",
-            "surname", "test",
-            "roles", ImmutableList.of(
-                ImmutableMap.of(
-                    "code", idamUserRole
-                )
-            )
-        );
-        String json = JsonUtils.toJson(body);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<String> request = new HttpEntity<>(json, headers);
-
-        SimpleClientHttpRequestFactory simpleClientHttpRequestFactory = new SimpleClientHttpRequestFactory();
-        simpleClientHttpRequestFactory.setOutputStreaming(false);
-        withValidHttpCodes(
-            new RestTemplate(simpleClientHttpRequestFactory),
-            rt -> {
-                ResponseEntity<String> responseEntity = rt
-                    .postForEntity(idamUrl + "/testing-support/accounts", request, String.class);
-
-                if (responseEntity.getStatusCodeValue() != 204) {
-                    fail("Could not create account in IdAM");
-                } else {
-                    findIdamUserIdByEmail();
-                }
-            },
-            401
-        );
-    }
-
     private void getIdamToken() {
-        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-        body.set("id", idamUser.toString());
-        body.set("role", idamUserRole);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
-        ResponseEntity<String> idamResponse = new RestTemplate()
-            .postForEntity(idamUrl + "/testing-support/lease", request, String.class);
-
-        if (idamResponse.hasBody()) {
-            testContext.getHttpContext().setIdamAuthorRef(idamResponse.getBody());
-        }
+        testContext.getHttpContext().setIdamAuthorRef(idamAuthentication.getToken());
     }
 
     private void getS2sToken() {

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/DeadlineSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/DeadlineSteps.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.coh.controller.question.AllQuestionsResponse;
 import uk.gov.hmcts.reform.coh.controller.question.QuestionResponse;
 import uk.gov.hmcts.reform.coh.domain.Question;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestContext;
+import uk.gov.hmcts.reform.coh.idam.IdamAuthentication;
 import uk.gov.hmcts.reform.coh.repository.QuestionRepository;
 import uk.gov.hmcts.reform.coh.schedule.notifiers.EventNotifierJob;
 import uk.gov.hmcts.reform.coh.service.utils.ExpiryCalendar;
@@ -50,8 +51,8 @@ public class DeadlineSteps extends BaseSteps {
     private ResponseErrorHandler oldErrorHandler;
 
     @Autowired
-    public DeadlineSteps(TestContext testContext) {
-        super(testContext);
+    public DeadlineSteps(TestContext testContext, IdamAuthentication idamAuthentication) {
+        super(testContext, idamAuthentication);
     }
 
     @Before

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/DecisionSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/DecisionSteps.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.coh.domain.Decision;
 import uk.gov.hmcts.reform.coh.domain.DecisionReply;
 import uk.gov.hmcts.reform.coh.functional.bdd.requests.CohEntityTypes;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestContext;
+import uk.gov.hmcts.reform.coh.idam.IdamAuthentication;
 import uk.gov.hmcts.reform.coh.repository.DecisionReplyRepository;
 import uk.gov.hmcts.reform.coh.states.DecisionsStates;
 import uk.gov.hmcts.reform.coh.utils.JsonUtils;
@@ -44,8 +45,8 @@ public class DecisionSteps extends BaseSteps {
     private DecisionReplyRepository decisionReplyRepository;
 
     @Autowired
-    public DecisionSteps(TestContext testContext){
-        super(testContext);
+    public DecisionSteps(TestContext testContext, IdamAuthentication idamAuthentication){
+        super(testContext, idamAuthentication);
     }
 
     @Before

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/EventSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/EventSteps.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.coh.controller.utils.CohUriBuilder;
 import uk.gov.hmcts.reform.coh.domain.*;
 import uk.gov.hmcts.reform.coh.functional.bdd.requests.CohEntityTypes;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestContext;
+import uk.gov.hmcts.reform.coh.idam.IdamAuthentication;
 import uk.gov.hmcts.reform.coh.repository.JurisdictionRepository;
 import uk.gov.hmcts.reform.coh.repository.SessionEventForwardingRegisterRepository;
 import uk.gov.hmcts.reform.coh.repository.SessionEventRepository;
@@ -66,8 +67,8 @@ public class EventSteps extends BaseSteps {
     private ResponseEntity<String> response;
 
     @Autowired
-    public EventSteps(TestContext testContext) {
-        super(testContext);
+    public EventSteps(TestContext testContext, IdamAuthentication idamAuthentication) {
+        super(testContext, idamAuthentication);
     }
 
     @Before

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/OnlineHearingSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/OnlineHearingSteps.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.coh.domain.RelistingHistory;
 import uk.gov.hmcts.reform.coh.domain.RelistingState;
 import uk.gov.hmcts.reform.coh.functional.bdd.requests.CohEntityTypes;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestContext;
+import uk.gov.hmcts.reform.coh.idam.IdamAuthentication;
 import uk.gov.hmcts.reform.coh.utils.JsonUtils;
 
 import java.io.IOException;
@@ -38,8 +39,8 @@ import static org.junit.Assert.assertThat;
 public class OnlineHearingSteps extends BaseSteps {
 
     @Autowired
-    public OnlineHearingSteps(TestContext testContext) {
-        super(testContext);
+    public OnlineHearingSteps(TestContext testContext, IdamAuthentication idamAuthentication) {
+        super(testContext, idamAuthentication);
     }
 
     @Before

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/QuestionSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/QuestionSteps.java
@@ -25,6 +25,7 @@ import uk.gov.hmcts.reform.coh.domain.QuestionStateHistory;
 import uk.gov.hmcts.reform.coh.functional.bdd.requests.CohEntityTypes;
 import uk.gov.hmcts.reform.coh.functional.bdd.responses.QuestionResponseUtils;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestContext;
+import uk.gov.hmcts.reform.coh.idam.IdamAuthentication;
 import uk.gov.hmcts.reform.coh.repository.QuestionRepository;
 
 import java.io.IOException;
@@ -48,8 +49,8 @@ public class QuestionSteps extends BaseSteps {
     private QuestionRepository questionRepository;
 
     @Autowired
-    public QuestionSteps(TestContext testContext) {
-        super(testContext);
+    public QuestionSteps(TestContext testContext, IdamAuthentication idamAuthentication) {
+        super(testContext, idamAuthentication);
     }
 
     @Before

--- a/src/aat/java/uk/gov/hmcts/reform/coh/idam/IdamAuthentication.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/idam/IdamAuthentication.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.reform.coh.idam;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.coh.idam.client.LoggingIdamClient;
+import uk.gov.hmcts.reform.coh.idam.client.RestTemplateIdamClient;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.PostConstruct;
+
+@Component
+@Scope("singleton")
+public class IdamAuthentication implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(IdamAuthentication.class);
+
+    private final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+
+    @Value("${base-urls.idam-url}")
+    protected String url;
+
+    @Value("${base-urls.idam-user-role}")
+    protected String role;
+
+    @Value("${base-urls.idam-user-email}")
+    private String email;
+
+    private long delay = 25;
+
+    private TimeUnit unit = TimeUnit.SECONDS;
+
+    private IdamClient client;
+
+    private String token;
+
+    @PostConstruct
+    public void init() {
+        client = new LoggingIdamClient(new RestTemplateIdamClient(url));
+        scheduledExecutor.scheduleWithFixedDelay(this::refreshToken, 0, delay, unit);
+    }
+
+    private void refreshToken() {
+        Integer userId = client.findUserByEmail(email);
+        if (userId == 0) {
+            client.createAccount(email, role);
+            userId = client.findUserByEmail(email);
+        }
+        token = client.lease(userId, role);
+        if (token != null && !"".equals(token)) {
+            log.info("Token refreshed");
+        } else {
+            log.warn("Empty token!");
+        }
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    @Override
+    public void close() throws Exception {
+        scheduledExecutor.shutdown();
+    }
+}

--- a/src/aat/java/uk/gov/hmcts/reform/coh/idam/IdamClient.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/idam/IdamClient.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.coh.idam;
+
+public interface IdamClient {
+
+    void createAccount(String email, String role);
+
+    Integer findUserByEmail(String email);
+
+    String lease(Integer userId, String role);
+}

--- a/src/aat/java/uk/gov/hmcts/reform/coh/idam/client/LoggingIdamClient.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/idam/client/LoggingIdamClient.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.coh.idam.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.reform.coh.idam.IdamClient;
+
+public class LoggingIdamClient implements IdamClient {
+
+    private static final Logger log = LoggerFactory.getLogger(LoggingIdamClient.class);
+    private final IdamClient subject;
+
+    public LoggingIdamClient(IdamClient subject) {
+        this.subject = subject;
+    }
+
+    @Override
+    public void createAccount(String email, String role) {
+        subject.createAccount(email, role);
+        log.info("Created account for {} as {}", email, role);
+    }
+
+    @Override
+    public Integer findUserByEmail(String email) {
+        Integer userId = subject.findUserByEmail(email);
+        log.info("Resolved {} as {}", email, userId);
+        return userId;
+    }
+
+    @Override
+    public String lease(Integer userId, String role) {
+        String token = subject.lease(userId, role);
+        log.info("Generated token for userId = {}: {}", userId, token);
+        return token;
+    }
+}

--- a/src/aat/java/uk/gov/hmcts/reform/coh/idam/client/RestTemplateIdamClient.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/idam/client/RestTemplateIdamClient.java
@@ -1,0 +1,147 @@
+package uk.gov.hmcts.reform.coh.idam.client;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import uk.gov.hmcts.reform.coh.idam.IdamClient;
+import uk.gov.hmcts.reform.coh.utils.JsonUtils;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public class RestTemplateIdamClient implements IdamClient {
+
+    private final String idamUrl;
+    private Integer idamUser = 0;
+
+    public RestTemplateIdamClient(String idamUrl) {
+        this.idamUrl = idamUrl;
+    }
+
+    private static void withValidHttpCodes(Consumer<RestTemplate> consumer, int... codes) {
+        withValidHttpCodes(new RestTemplate(), consumer, codes);
+    }
+
+    private static void withValidHttpCodes(RestTemplate rt, Consumer<RestTemplate> consumer, int... codes) {
+        ResponseErrorHandler oldErrorHandler = rt.getErrorHandler();
+        rt.setErrorHandler(new ResponseErrorHandler() {
+            @Override
+            public boolean hasError(ClientHttpResponse response) throws IOException {
+                for (int code : codes) {
+                    if (response.getRawStatusCode() == code) {
+                        return false;
+                    }
+                }
+                return oldErrorHandler.hasError(response);
+            }
+
+            @Override
+            public void handleError(ClientHttpResponse response) throws IOException {
+                oldErrorHandler.handleError(response);
+            }
+        });
+        consumer.accept(rt);
+    }
+
+    @Override
+    public void createAccount(String email, String role) {
+        String password = UUID.randomUUID().toString();
+        ImmutableMap<String, Object> body = ImmutableMap.of(
+            "email", email,
+            "password", password,
+            "forename", "test",
+            "surname", "test",
+            "roles", ImmutableList.of(
+                ImmutableMap.of(
+                    "code", role
+                )
+            )
+        );
+
+        String json;
+        try {
+            json = JsonUtils.toJson(body);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> request = new HttpEntity<>(json, headers);
+
+        SimpleClientHttpRequestFactory simpleClientHttpRequestFactory = new SimpleClientHttpRequestFactory();
+        simpleClientHttpRequestFactory.setOutputStreaming(false);
+        withValidHttpCodes(
+            new RestTemplate(simpleClientHttpRequestFactory),
+            rt -> {
+                ResponseEntity<String> responseEntity = rt
+                    .postForEntity(idamUrl + "/testing-support/accounts", request, String.class);
+
+                if (responseEntity.getStatusCodeValue() != 204) {
+                    fail("Could not create account in IdAM");
+                } else {
+                    idamUser = findUserByEmail(email);
+                }
+            },
+            401
+        );
+    }
+
+    @Override
+    public Integer findUserByEmail(String email) {
+        String usersUri = UriComponentsBuilder.fromUriString(idamUrl)
+            .path("/testing-support/accounts/" + email)
+            .toUriString();
+
+        withValidHttpCodes(
+            rt -> {
+                ResponseEntity<Map> response = rt.getForEntity(usersUri, Map.class);
+                if (response.getStatusCode() == HttpStatus.OK
+                    && response.hasBody()
+                    && response.getBody().containsKey("id")) {
+
+                    idamUser = (Integer) response.getBody().get("id");
+                }
+            },
+            404
+        );
+        return idamUser;
+    }
+
+    @Override
+    public String lease(Integer userId, String role) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.set("id", idamUser.toString());
+        body.set("role", role);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        ResponseEntity<String> response = new RestTemplate()
+            .postForEntity(idamUrl + "/testing-support/lease", request, String.class);
+
+        if (response.hasBody()) {
+            return response.getBody();
+        } else {
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
Less overhead related to querying for new token.

Token is refreshed every 25 seconds in the background.