### PR TITLE
Return existing session event if one already pending

### DIFF
--- a/src/aat/resources/cucumber/distinct-notifications.feature
+++ b/src/aat/resources/cucumber/distinct-notifications.feature
@@ -1,0 +1,6 @@
+Feature: Distinct Notifications
+
+  Scenario: Creating two same events
+    Given a standard online hearing is created
+    When 2 question_round_issued events are added
+    Then there are 1 question_round_issued events in the queue

--- a/src/main/java/uk/gov/hmcts/reform/coh/repository/SessionEventRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/repository/SessionEventRepository.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.coh.domain.SessionEventForwardingRegister;
 import uk.gov.hmcts.reform.coh.domain.SessionEventForwardingState;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -25,4 +26,10 @@ public interface SessionEventRepository extends CrudRepository<SessionEvent, UUI
     List<SessionEvent> findAllBySessionEventForwardingRegister(SessionEventForwardingRegister sessionEventForwardingRegister);
 
     List<SessionEvent> findAllBySessionEventForwardingRegisterAndSessionEventForwardingState(SessionEventForwardingRegister sessionEventForwardingRegister, SessionEventForwardingState eventForwardingState);
+
+    Optional<SessionEvent> findFirstByOnlineHearingAndSessionEventForwardingRegisterAndSessionEventForwardingState(
+        OnlineHearing onlineHearing,
+        SessionEventForwardingRegister sessionEventForwardingRegister,
+        SessionEventForwardingState sessionEventForwardingState
+    );
 }


### PR DESCRIPTION
Prevent creating multiple session events (and notification spamming).