### PR TITLE
Update dependency suppressions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,13 +44,6 @@ configurations.all {
             details.useVersion "8.5.34"
             details.because "https://nvd.nist.gov/vuln/detail/CVE-2018-8034"
         }
-        if (details.requested.group == 'com.fasterxml.jackson.core'
-                && details.requested.name == 'jackson-databind'
-                && details.requested.version == '2.9.5') {
-
-            details.useVersion "2.9.8"
-            details.because "https://github.com/FasterXML/jackson-databind/issues/2186"
-        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,11 +35,6 @@ repositories {
     mavenLocal()
 }
 
-configurations.all {
-    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-    }
-}
-
 dependencyCheck {
     // Specifies if the build should be failed if a CVSS score above a specified level is identified.
     // range of 0-10 fails the build, anything greater and it doesn't fail the build

--- a/build.gradle
+++ b/build.gradle
@@ -37,13 +37,6 @@ repositories {
 
 configurations.all {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-        if (details.requested.group == 'org.apache.tomcat.embed'
-                && details.requested.name == 'tomcat-embed-core'
-                && details.requested.version == '8.5.29') {
-
-            details.useVersion "8.5.34"
-            details.because "https://nvd.nist.gov/vuln/detail/CVE-2018-8034"
-        }
     }
 }
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -125,11 +125,4 @@
         <cve>CVE-2018-10237</cve>
     </suppress>
 
-    <suppress>
-        <notes><![CDATA[
-   relates to CETS
-   ]]></notes>
-        <gav regex="true">.*</gav>
-        <cve>CVE-2018-8088</cve>
-    </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -29,41 +29,6 @@
         <gav regex="true">com.thoughtworks.xstream:xstream:1.4.8</gav>
         <cpe>cpe:/a:xstream_project:xstream:1.4.8</cpe>
     </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: tomcat-embed-websocket-8.5.29.jar
-   ]]></notes>
-        <gav regex="true">^org\.apache\.tomcat\.embed:tomcat-embed-websocket:.*$</gav>
-        <cpe>cpe:/a:apache:tomcat</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: tomcat-embed-websocket-8.5.29.jar
-   ]]></notes>
-        <gav regex="true">^org\.apache\.tomcat\.embed:tomcat-embed-websocket:.*$</gav>
-        <cpe>cpe:/a:apache_tomcat:apache_tomcat</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: tomcat-embed-websocket-8.5.29.jar
-   ]]></notes>
-        <gav regex="true">^org\.apache\.tomcat\.embed:tomcat-embed-websocket:.*$</gav>
-        <cpe>cpe:/a:apache_software_foundation:tomcat</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: tomcat-embed-websocket-8.5.29.jar
-   ]]></notes>
-        <gav regex="true">^org\.apache\.tomcat\.embed:tomcat-embed-websocket:.*$</gav>
-        <cve>CVE-2018-8014</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: tomcat-embed-core-8.5.29.jar
-   ]]></notes>
-        <gav regex="true">^org\.apache\.tomcat\.embed:tomcat-embed-core:.*$</gav>
-        <cve>CVE-2018-8014</cve>
-    </suppress>
 
     <suppress>
         <notes><![CDATA[


### PR DESCRIPTION
Upgrading Spring (please see PR #260) brought also new versions of packages that previously had been found vulnerable. Now the CVEs can be removed from dependency suppression list.