### PR TITLE
Stop logging potentially sensitive data

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/coh/controller/AnswerController.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/controller/AnswerController.java
@@ -266,7 +266,6 @@ public class AnswerController {
             eventRepository.trackEvent("Not found answer error", ImmutableMap.of(
                 "onlineHearingId", onlineHearingId.toString(),
                 "answerId", answerId.toString(),
-                "requestedText", request.getAnswerText(),
                 "requestedState", request.getAnswerState(),
                 "error", e.getMessage()
             ));

--- a/src/test/java/uk/gov/hmcts/reform/coh/controller/LoggingAnswerUpdateErrorsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/coh/controller/LoggingAnswerUpdateErrorsTest.java
@@ -234,6 +234,6 @@ public class LoggingAnswerUpdateErrorsTest {
         assertThat(trackedEventProperties.getValue())
             .containsEntry("onlineHearingId", onlineHearingId)
             .containsEntry("answerId", answer.getAnswerId().toString())
-            .containsKeys("requestedText", "requestedState", "error");
+            .containsKeys("requestedState", "error");
     }
 }


### PR DESCRIPTION
Answer text may contain personal information.